### PR TITLE
Update service-io dependency version to 2.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 
 dependencies {
     compileOnly("org.projectlombok:lombok:1.18.36")
-    compileOnly("net.thenextlvl.services:service-io:2.1.0")
+    compileOnly("net.thenextlvl.services:service-io:2.2.0")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT") {
         exclude("org.jetbrains", "annotations")
     }


### PR DESCRIPTION
Upgraded the net.thenextlvl.services:service-io library from version 2.1.0 to 2.2.0 to incorporate the latest improvements and fixes. This ensures better compatibility and optimizations in the build.