### PR TITLE
Add permission to bypass teleport cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Alternatively, you can use the command:
 | `cooldown-allow-movement` | Allows movement during teleport cooldown.               |
 | `tpa-timeout`             | Timeout duration in milliseconds for teleport requests. |
 
+The permission to bypass the teleportation cooldown is `tweaks.teleport.cooldown.bypass`
+
 ## Animals Configuration
 
 | Option                       | Description                                                               |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,6 +165,7 @@ paper {
 
         register("tweaks.chat.delete") { this.children = listOf("tweaks.chat.delete.own") }
 
+        register("tweaks.teleport.cooldown.bypass") { this.default = BukkitPluginDescription.Permission.Default.OP }
 
         register("tweaks.commands.environmental") {
             this.description = "Grants access to all environmental commands"

--- a/src/main/java/net/thenextlvl/tweaks/controller/TeleportController.java
+++ b/src/main/java/net/thenextlvl/tweaks/controller/TeleportController.java
@@ -22,7 +22,8 @@ public class TeleportController {
 
     public CompletableFuture<Boolean> teleport(Player player, Location location, PlayerTeleportEvent.TeleportCause cause) {
         var cooldown = plugin.config().teleport().cooldown();
-        if (cooldown <= 0) return player.teleportAsync(location, cause);
+        if (cooldown <= 0 || player.hasPermission("tweaks.teleport.cooldown.bypass"))
+            return player.teleportAsync(location, cause);
         if (location.equals(teleports.put(player, location)))
             return CompletableFuture.failedFuture(new IllegalStateException());
         var formatter = DecimalFormat.getInstance(player.locale());


### PR DESCRIPTION
Introduced `tweaks.teleport.cooldown.bypass` permission, allowing players with this permission to skip the teleportation cooldown. Updated `README.md` and `TeleportController` logic to reflect this change and registered the permission with OP as default.