### PR TITLE
Add TrashCommand to manage player inventory disposal

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,6 +210,7 @@ paper {
                 "tweaks.command.seen",
                 "tweaks.command.speed",
                 "tweaks.command.suicide",
+                "tweaks.command.trash",
                 "tweaks.command.vanish"
             )
         }

--- a/src/main/java/net/thenextlvl/tweaks/TweaksPlugin.java
+++ b/src/main/java/net/thenextlvl/tweaks/TweaksPlugin.java
@@ -181,6 +181,7 @@ public class TweaksPlugin extends JavaPlugin {
         if (commands().seen().enabled()) new SeenCommand(this).register(registrar);
         if (commands().speed().enabled()) new SpeedCommand(this).register(registrar);
         if (commands().suicide().enabled()) new SuicideCommand(this).register(registrar);
+        if (commands().trash().enabled()) new TrashCommand(this).register(registrar);
         if (commands().vanish().enabled()) new VanishCommand(this).register(registrar);
     }
 

--- a/src/main/java/net/thenextlvl/tweaks/command/player/TrashCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/TrashCommand.java
@@ -1,0 +1,35 @@
+package net.thenextlvl.tweaks.command.player;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
+import io.papermc.paper.command.brigadier.Commands;
+import lombok.RequiredArgsConstructor;
+import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+@RequiredArgsConstructor
+@SuppressWarnings("UnstableApiUsage")
+public class TrashCommand {
+    private final TweaksPlugin plugin;
+
+    public void register(Commands registrar) {
+        var command = Commands.literal(plugin.commands().trash().command())
+                .requires(stack -> stack.getSender() instanceof Player player
+                                   && player.hasPermission("tweaks.command.trash"))
+                .executes(this::trash)
+                .build();
+        registrar.register(command, "Dispose of your unwanted items", plugin.commands().hat().aliases());
+    }
+
+    private int trash(CommandContext<CommandSourceStack> context) {
+        var player = (Player) context.getSource().getSender();
+        player.openInventory(MenuType.GENERIC_9X4.create(player,
+                plugin.bundle().component(player, "gui.title.trash")
+        ));
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/net/thenextlvl/tweaks/model/CommandConfig.java
+++ b/src/main/java/net/thenextlvl/tweaks/model/CommandConfig.java
@@ -56,6 +56,7 @@ public class CommandConfig {
     private @SerializedName("seen") CommandDefinition seen = new CommandDefinition("seen", "find");
     private @SerializedName("speed") CommandDefinition speed = new CommandDefinition("speed");
     private @SerializedName("suicide") CommandDefinition suicide = new CommandDefinition("suicide");
+    private @SerializedName("trash") CommandDefinition trash = new CommandDefinition("trash", "dispose", "garbage");
     private @SerializedName("vanish") CommandDefinition vanish = new CommandDefinition("vanish", "v", "invisible");
 
     private @SerializedName("broadcast") CommandDefinition broadcast = new CommandDefinition("broadcast", "bc");

--- a/src/main/resources/tweaks.properties
+++ b/src/main/resources/tweaks.properties
@@ -136,6 +136,7 @@ gui.placeholder.helmet=<dark_gray>»</dark_gray> <green>Helmet</green>
 gui.placeholder.leggings=<dark_gray>»</dark_gray> <green>Leggings</green>
 gui.placeholder.off-hand=<dark_gray>»</dark_gray> <aqua>Off Hand</aqua>
 gui.title.homes=Your Homes
+gui.title.trash=Trash
 gui.title.warps=Warps
 nothing.changed=<red><prefix> Nothing could be changed</red>
 player.connected=<gray><prefix> <click:suggest_command:'/tell <player> '><green><chat_display_name></green></click> joined the game</gray>


### PR DESCRIPTION
Implemented a new `/trash` command allowing players to open a virtual trash GUI for item disposal. Updated configuration, permissions, and localization files to support the command and integrated it into the plugin's command registration system.

closes #53 