### PR TITLE
Fix null world checks in spawn handling logic

### DIFF
--- a/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
@@ -22,15 +22,16 @@ public class SpawnCommand {
                 .executes(context -> {
                     var player = (Player) context.getSource().getSender();
                     var location = plugin.config().spawn().location();
-                    if (location == null) {
+                    if (location == null || location.getWorld() == null) {
                         plugin.bundle().sendMessage(player, "command.spawn.undefined");
                         if (player.hasPermission("tweaks.command.setspawn"))
                             plugin.bundle().sendMessage(player, "command.spawn.define");
+                        return 0;
                     } else plugin.teleportController().teleport(player, location, COMMAND).thenAccept(success -> {
                         var message = success ? "command.spawn" : "command.teleport.cancelled";
                         plugin.bundle().sendMessage(player, message);
                     });
-                    return location != null ? Command.SINGLE_SUCCESS : 0;
+                    return Command.SINGLE_SUCCESS;
                 }).build();
         registrar.register(command, "Teleport you to spawn", plugin.commands().spawn().aliases());
     }

--- a/src/main/java/net/thenextlvl/tweaks/listener/SpawnListener.java
+++ b/src/main/java/net/thenextlvl/tweaks/listener/SpawnListener.java
@@ -18,7 +18,7 @@ public class SpawnListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerSpawnLocation(PlayerSpawnLocationEvent event) {
         var config = plugin.config().spawn();
-        if (config.location() == null) return;
+        if (config.location() == null || config.location().getWorld() == null) return;
         if ((!config.teleportOnFirstJoin() || event.getPlayer().hasPlayedBefore())
             && (!config.teleportOnJoin() || !event.getPlayer().hasPlayedBefore())) return;
         event.setSpawnLocation(config.location());
@@ -28,7 +28,7 @@ public class SpawnListener implements Listener {
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         if (!event.getRespawnReason().equals(PlayerRespawnEvent.RespawnReason.DEATH)) return;
         var config = plugin.config().spawn();
-        if (config.location() == null || !config.teleportOnRespawn()) return;
+        if (config.location() == null || config.location().getWorld() == null || !config.teleportOnRespawn()) return;
         if (!config.ignoreRespawnPosition() && (event.isAnchorSpawn() || event.isBedSpawn())) return;
         event.setRespawnLocation(config.location());
     }
@@ -36,7 +36,7 @@ public class SpawnListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerDeath(PlayerDeathEvent event) {
         var config = plugin.config().spawn();
-        if (config.location() == null || !config.teleportOnRespawn()) return;
+        if (config.location() == null || config.location().getWorld() == null || !config.teleportOnRespawn()) return;
         if (config.ignoreRespawnPosition()) event.getPlayer().setRespawnLocation(null);
     }
 }


### PR DESCRIPTION
Added checks to ensure the spawn location's world is not null in listener methods and the spawn command. This prevents potential errors when accessing invalid or undefined worlds in the spawn configuration.
closes #68 