### PR TITLE
1.21.5 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,13 +30,13 @@ repositories {
 
 dependencies {
     compileOnly("net.thenextlvl.services:service-io:2.2.0")
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
 
     implementation("net.thenextlvl.core:adapters:2.0.2")
     implementation("net.thenextlvl.core:files:3.0.0")
     implementation("net.thenextlvl.core:i18n:3.2.0")
     implementation("net.thenextlvl.core:nbt:2.3.2")
-    implementation("net.thenextlvl.core:paper:2.1.1")
+    implementation("net.thenextlvl.core:paper:2.1.2")
     implementation("org.bstats:bstats-bukkit:3.1.0")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-gameVersions=1.21.3,1.21.4
+gameVersions=1.21.5

--- a/src/main/java/net/thenextlvl/tweaks/command/item/UnbreakableCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/UnbreakableCommand.java
@@ -5,7 +5,6 @@ import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.datacomponent.DataComponentTypes;
-import io.papermc.paper.datacomponent.item.Unbreakable;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -37,7 +36,7 @@ public class UnbreakableCommand {
             item.resetData(DataComponentTypes.UNBREAKABLE);
             plugin.bundle().sendMessage(player, "command.item.unbreakable.removed");
         } else {
-            item.setData(DataComponentTypes.UNBREAKABLE, Unbreakable.unbreakable().build());
+            item.setData(DataComponentTypes.UNBREAKABLE);
             plugin.bundle().sendMessage(player, "command.item.unbreakable.success");
         }
         return Command.SINGLE_SUCCESS;


### PR DESCRIPTION
Upgraded `paper-api` to 1.21.5 and `net.thenextlvl.core:paper` to 2.1.2.