### PR TITLE
Replace `Placeholder.parsed` with `Formatter.number`

### DIFF
--- a/src/main/java/net/thenextlvl/tweaks/command/environment/weather/WeatherCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/weather/WeatherCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.World;
@@ -72,7 +73,7 @@ public class WeatherCommand {
         if (rain || thunder) world.setWeatherDuration(duration);
         else world.setClearWeatherDuration(duration);
         plugin.bundle().sendMessage(sender, message,
-                Placeholder.parsed("duration", String.valueOf(duration)),
+                Formatter.number("duration", duration),
                 Placeholder.parsed("world", world.getName()));
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/home/SetHomeCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/home/SetHomeCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.HomeSuggestionProvider;
@@ -47,7 +48,7 @@ public class SetHomeCommand {
                 }
                 var count = plugin.dataController().getHomeCount(player);
                 if (count >= limit) plugin.bundle().sendMessage(player, "command.home.limit",
-                        Placeholder.parsed("limit", String.valueOf(limit)));
+                        Formatter.number("limit", limit));
                 else setHome(name, player);
             }
         });

--- a/src/main/java/net/thenextlvl/tweaks/command/item/ItemCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/ItemCommand.java
@@ -7,6 +7,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.entity.Player;
@@ -62,7 +63,7 @@ public class ItemCommand {
         }
 
         plugin.bundle().sendMessage(player, "command.item.received",
-                Placeholder.parsed("amount", String.valueOf(added)),
+                Formatter.number("amount", added),
                 Placeholder.component("item", Component.translatable(item)
                         .hoverEvent(item.asHoverEvent(showItem -> showItem))));
 

--- a/src/main/java/net/thenextlvl/tweaks/command/player/PingCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/PingCommand.java
@@ -2,6 +2,7 @@ package net.thenextlvl.tweaks.command.player;
 
 import com.mojang.brigadier.Command;
 import io.papermc.paper.command.brigadier.Commands;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.command.CommandSender;
@@ -23,9 +24,9 @@ public class PingCommand extends PlayerCommand {
     protected int execute(CommandSender sender, Player player) {
         if (sender != player) plugin.bundle().sendMessage(sender, "command.ping.others",
                 Placeholder.parsed("player", player.getName()),
-                Placeholder.parsed("ping", String.valueOf(player.getPing())));
+                Formatter.number("ping", player.getPing()));
         else plugin.bundle().sendMessage(player, "command.ping.self",
-                Placeholder.parsed("ping", String.valueOf(player.getPing())));
+                Formatter.number("ping", player.getPing()));
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/player/SpeedCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/SpeedCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import io.papermc.paper.command.brigadier.argument.resolvers.selector.EntitySelectorArgumentResolver;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.NamespacedKey;
@@ -141,9 +142,9 @@ public class SpeedCommand {
             }
 
             plugin.bundle().sendMessage(entity, type.getMessageSelf(),
-                    Placeholder.parsed("speed", String.valueOf(speed)));
+                    Formatter.number("speed", speed));
             if (!entity.equals(sender)) plugin.bundle().sendMessage(sender, type.getMessageOther(),
-                    Placeholder.parsed("speed", String.valueOf(speed)),
+                    Formatter.number("speed", speed),
                     Placeholder.component("entity", entity.name().hoverEvent(entity.asHoverEvent())));
         });
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/net/thenextlvl/tweaks/listener/ConnectionListener.java
+++ b/src/main/java/net/thenextlvl/tweaks/listener/ConnectionListener.java
@@ -1,6 +1,6 @@
 package net.thenextlvl.tweaks.listener;
 
-import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -27,7 +27,7 @@ public class ConnectionListener implements Listener {
                 : plugin.getServer().getOfflinePlayers().length;
         var message = event.getPlayer().hasPlayedBefore() ? "player.connected" : "player.welcome";
         var resolvers = plugin.serviceResolvers(event.getPlayer())
-                .resolver(Placeholder.parsed("id", String.valueOf(id)))
+                .resolver(Formatter.number("id", id))
                 .build();
         plugin.getServer().forEachAudience(audience -> plugin.bundle().sendMessage(
                 audience, message, resolvers


### PR DESCRIPTION
Refactored code to improve readability and consistency by using `Formatter.number` instead of `Placeholder.parsed` for numeric message formatting.