### PR TITLE
Renamed teleport cause `CHORUS_FRUIT` to `CONSUMABLE_EFFECT`

### DIFF
--- a/src/main/java/net/thenextlvl/tweaks/listener/BackListener.java
+++ b/src/main/java/net/thenextlvl/tweaks/listener/BackListener.java
@@ -22,7 +22,7 @@ public class BackListener implements Listener {
     public void onTeleport(PlayerTeleportEvent event) {
         if (switch (event.getCause()) { // todo: config entry
             case ENDER_PEARL, COMMAND, PLUGIN, END_PORTAL, SPECTATE, UNKNOWN -> false;
-            case NETHER_PORTAL, END_GATEWAY, CHORUS_FRUIT, DISMOUNT, EXIT_BED -> true;
+            case NETHER_PORTAL, END_GATEWAY, CONSUMABLE_EFFECT, DISMOUNT, EXIT_BED -> true;
         }) return;
 
         var player = event.getPlayer();


### PR DESCRIPTION
Updated switch statement to reflect the renamed teleport cause.