### PR TITLE
Respect `sendCommandFeedback` game rule

### DIFF
--- a/src/main/java/net/thenextlvl/tweaks/command/environment/time/DayCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/time/DayCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
@@ -21,7 +22,8 @@ public class DayCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.time.day", Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.time.day", Placeholder.parsed("world", world.getName()));
         world.setTime(1000);
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/time/MidnightCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/time/MidnightCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
@@ -21,8 +22,8 @@ public class MidnightCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.time.midnight",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.time.midnight", Placeholder.parsed("world", world.getName()));
         world.setTime(18000);
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/time/NightCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/time/NightCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
@@ -21,8 +22,8 @@ public class NightCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.time.night",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.time.night", Placeholder.parsed("world", world.getName()));
         world.setTime(13000);
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/time/NoonCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/time/NoonCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.jspecify.annotations.NullMarked;
@@ -21,8 +22,8 @@ public class NoonCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.time.noon",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.time.noon", Placeholder.parsed("world", world.getName()));
         world.setTime(6000);
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/time/TimeCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/time/TimeCommand.java
@@ -10,6 +10,7 @@ import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.jspecify.annotations.NullMarked;
 
@@ -85,9 +86,10 @@ public class TimeCommand {
     private int setTime(CommandContext<CommandSourceStack> context, long ticks, World world) {
         var sender = context.getSource().getSender();
         plugin.getServer().getGlobalRegionScheduler().run(plugin, task -> world.setTime(ticks));
-        plugin.bundle().sendMessage(sender, "command.time.set",
-                Formatter.number("time", ticks),
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.time.set",
+                    Formatter.number("time", ticks),
+                    Placeholder.parsed("world", world.getName()));
         return Command.SINGLE_SUCCESS;
     }
 

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/weather/RainCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/weather/RainCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 
@@ -19,8 +20,8 @@ public class RainCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.weather.rain",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.weather.rain", Placeholder.parsed("world", world.getName()));
         world.setThundering(false);
         world.setStorm(true);
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/weather/SunCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/weather/SunCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 
@@ -19,8 +20,8 @@ public class SunCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.weather.sun",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.weather.sun", Placeholder.parsed("world", world.getName()));
         world.setThundering(false);
         world.setStorm(false);
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/weather/ThunderCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/weather/ThunderCommand.java
@@ -4,6 +4,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.environment.WorldCommand;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 
@@ -19,8 +20,8 @@ public class ThunderCommand extends WorldCommand {
 
     @Override
     protected void execute(CommandSender sender, World world) {
-        plugin.bundle().sendMessage(sender, "command.weather.thunder",
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, "command.weather.thunder", Placeholder.parsed("world", world.getName()));
         world.setThundering(true);
         world.setStorm(true);
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/environment/weather/WeatherCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/environment/weather/WeatherCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 
@@ -74,8 +75,9 @@ public class WeatherCommand {
             if (rain || thunder) world.setWeatherDuration(duration);
             else world.setClearWeatherDuration(duration);
         });
-        plugin.bundle().sendMessage(sender, message,
-                Formatter.number("duration", duration),
-                Placeholder.parsed("world", world.getName()));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(sender, message,
+                    Formatter.number("duration", duration),
+                    Placeholder.parsed("world", world.getName()));
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/item/EnchantCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/EnchantCommand.java
@@ -16,6 +16,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.EnchantSuggestionProvider;
+import org.bukkit.GameRule;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -89,8 +90,9 @@ public class EnchantCommand {
         level = Math.max(level, enchantment.getStartLevel());
 
         item.addUnsafeEnchantment(enchantment, level);
-        plugin.bundle().sendMessage(player, "command.enchantment.applied", Placeholder.component("enchantment",
-                enchantment.displayName(level).style(Style.empty())));
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.enchantment.applied",
+                    Placeholder.component("enchantment", enchantment.displayName(level).style(Style.empty())));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/item/HeadCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/HeadCommand.java
@@ -12,6 +12,7 @@ import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.OfflinePlayerSuggestionProvider;
+import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -54,7 +55,8 @@ public class HeadCommand {
         var head = ItemBuilder.of(Material.PLAYER_HEAD)
                 .profile(context.getArgument("player", String.class));
         player.getInventory().addItem(head.item());
-        plugin.bundle().sendMessage(player, "command.item.head.received");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.item.head.received");
         return Command.SINGLE_SUCCESS;
     }
 
@@ -63,7 +65,8 @@ public class HeadCommand {
         var head = ItemBuilder.of(Material.PLAYER_HEAD)
                 .profileValue(context.getArgument("value", String.class));
         player.getInventory().addItem(head.item());
-        plugin.bundle().sendMessage(player, "command.item.head.received");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.item.head.received");
         return Command.SINGLE_SUCCESS;
     }
 
@@ -72,7 +75,8 @@ public class HeadCommand {
         var head = ItemBuilder.of(Material.PLAYER_HEAD)
                 .profileUrl(context.getArgument("url", String.class));
         player.getInventory().addItem(head.item());
-        plugin.bundle().sendMessage(player, "command.item.head.received");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.item.head.received");
         return Command.SINGLE_SUCCESS;
     }
 

--- a/src/main/java/net/thenextlvl/tweaks/command/item/ItemCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/ItemCommand.java
@@ -10,6 +10,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
@@ -62,10 +63,10 @@ public class ItemCommand {
             return 0;
         }
 
-        plugin.bundle().sendMessage(player, "command.item.received",
-                Formatter.number("amount", added),
-                Placeholder.component("item", Component.translatable(item)
-                        .hoverEvent(item.asHoverEvent(showItem -> showItem))));
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.item.received", Formatter.number("amount", added),
+                    Placeholder.component("item", Component.translatable(item)
+                            .hoverEvent(item.asHoverEvent(showItem -> showItem))));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/item/LoreCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/LoreCommand.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -113,7 +114,8 @@ public class LoreCommand {
         var success = !item.isEmpty() && function.apply(ItemBuilder.of(item));
         var message = item.isEmpty() ? "command.hold.item" : success ? "command.item.lore" : "nothing.changed";
 
-        plugin.bundle().sendMessage(player, message);
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(player, message);
         return success ? Command.SINGLE_SUCCESS : 0;
     }
 

--- a/src/main/java/net/thenextlvl/tweaks/command/item/RenameCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/RenameCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -39,7 +40,8 @@ public class RenameCommand {
         var success = !name.equals(item.getData(DataComponentTypes.CUSTOM_NAME));
         if (success) item.setData(DataComponentTypes.CUSTOM_NAME, name);
         var message = item.isEmpty() ? "command.hold.item" : success ? "command.item.rename" : "nothing.changed";
-        plugin.bundle().sendMessage(player, message);
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(player, message);
 
         return success ? Command.SINGLE_SUCCESS : 0;
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/item/RepairCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/RepairCommand.java
@@ -6,6 +6,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
@@ -44,7 +45,8 @@ public class RepairCommand {
         var success = repair(inventory.getItemInMainHand());
         var message = success ? "command.item.repaired.success" : "command.item.repaired.fail";
 
-        plugin.bundle().sendMessage(player, message);
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(player, message);
         return success ? Command.SINGLE_SUCCESS : 0;
     }
 
@@ -52,7 +54,8 @@ public class RepairCommand {
         var player = (Player) context.getSource().getSender();
         var inventory = player.getInventory();
         var success = Arrays.stream(inventory.getContents()).map(this::repair).reduce(false, Boolean::logicalOr);
-        plugin.bundle().sendMessage(player, success ? "command.item.repaired.all" : "command.item.repaired.none");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(player, success ? "command.item.repaired.all" : "command.item.repaired.none");
         return success ? Command.SINGLE_SUCCESS : 0;
     }
 

--- a/src/main/java/net/thenextlvl/tweaks/command/item/UnbreakableCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/UnbreakableCommand.java
@@ -6,6 +6,7 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -34,10 +35,12 @@ public class UnbreakableCommand {
             return 0;
         } else if (item.hasData(DataComponentTypes.UNBREAKABLE)) {
             item.resetData(DataComponentTypes.UNBREAKABLE);
-            plugin.bundle().sendMessage(player, "command.item.unbreakable.removed");
+            if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+                plugin.bundle().sendMessage(player, "command.item.unbreakable.removed");
         } else {
             item.setData(DataComponentTypes.UNBREAKABLE);
-            plugin.bundle().sendMessage(player, "command.item.unbreakable.success");
+            if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+                plugin.bundle().sendMessage(player, "command.item.unbreakable.success");
         }
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/item/UnenchantCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/UnenchantCommand.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.UnenchantSuggestionProvider;
+import org.bukkit.GameRule;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -52,8 +53,11 @@ public class UnenchantCommand {
         var level = item.removeEnchantment(enchantment);
 
         var message = level != 0 ? "command.enchantment.removed" : "command.enchantment.absent";
-        plugin.bundle().sendMessage(player, message, Placeholder.component("enchantment",
-                enchantment.displayName(level).style(Style.empty())));
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || level == 0) {
+            var clamped = Math.clamp(level, enchantment.getStartLevel(), enchantment.getMaxLevel());
+            plugin.bundle().sendMessage(player, message, Placeholder.component("enchantment",
+                    enchantment.displayName(clamped).style(Style.empty())));
+        }
         return level != 0 ? Command.SINGLE_SUCCESS : 0;
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/player/BackCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/BackCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -42,7 +43,8 @@ public class BackCommand {
         plugin.teleportController().teleport(player, location, COMMAND).thenAccept(success -> {
             var message = success ? "command.back" : "command.teleport.cancelled";
             if (success) plugin.backController().remove(player, location);
-            plugin.bundle().sendMessage(player, message);
+            if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+                plugin.bundle().sendMessage(player, message);
         });
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/net/thenextlvl/tweaks/command/player/FeedCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/FeedCommand.java
@@ -3,6 +3,7 @@ package net.thenextlvl.tweaks.command.player;
 import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.command.CommandSender;
@@ -27,6 +28,9 @@ public class FeedCommand extends PlayersCommand {
         player.setSaturation(20f);
 
         player.playSound(player, Sound.ENTITY_PLAYER_BURP, SoundCategory.VOICE, 1f, 1f);
+
+        if (Boolean.FALSE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
+
         plugin.bundle().sendMessage(player, "command.hunger.satisfied.self");
         if (player != sender) plugin.bundle().sendMessage(sender, "command.hunger.satisfied.others",
                 Placeholder.parsed("player", player.getName()));

--- a/src/main/java/net/thenextlvl/tweaks/command/player/FlyCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/FlyCommand.java
@@ -3,6 +3,7 @@ package net.thenextlvl.tweaks.command.player;
 import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
@@ -22,6 +23,8 @@ public class FlyCommand extends PlayersCommand {
     protected void execute(CommandSender sender, Player player) {
         player.setAllowFlight(!player.getAllowFlight());
         player.setFlying(player.getAllowFlight());
+
+        if (Boolean.FALSE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
 
         var messageSelf = player.getAllowFlight() ? "command.flight.enabled.self" : "command.flight.disabled.self";
         var messageOthers = player.getAllowFlight() ? "command.flight.enabled.others" : "command.flight.disabled.others";

--- a/src/main/java/net/thenextlvl/tweaks/command/player/GameModeCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/GameModeCommand.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.argument.GameModeArgumentType;
 import org.bukkit.GameMode;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -50,6 +51,8 @@ public class GameModeCommand {
         resolve.forEach(player -> {
             player.setGameMode(gamemode);
 
+            if (Boolean.FALSE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
+        
             plugin.bundle().sendMessage(player, "command.gamemode.changed.self", Placeholder.component("gamemode",
                     Component.translatable(gamemode)));
 

--- a/src/main/java/net/thenextlvl/tweaks/command/player/HatCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/HatCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.entity.Player;
@@ -39,7 +40,8 @@ public class HatCommand {
         }
 
         player.playSound(player, Sound.ITEM_ARMOR_EQUIP_GENERIC, SoundCategory.PLAYERS, 1f, 1f);
-        plugin.bundle().sendMessage(player, "command.hat.equipped");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.hat.equipped");
         inventory.setItemInMainHand(helmet);
         inventory.setHelmet(item);
 

--- a/src/main/java/net/thenextlvl/tweaks/command/player/HealCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/HealCommand.java
@@ -3,6 +3,7 @@ package net.thenextlvl.tweaks.command.player;
 import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -40,6 +41,8 @@ public class HealCommand extends EntitiesCommand {
 
         entity.setFireTicks(0);
         entity.setFreezeTicks(0);
+
+        if (Boolean.FALSE.equals(entity.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
 
         plugin.bundle().sendMessage(entity, "command.health.restored.self");
         if (entity != sender) plugin.bundle().sendMessage(sender, "command.health.restored.others",

--- a/src/main/java/net/thenextlvl/tweaks/command/player/OfflineTeleportCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/OfflineTeleportCommand.java
@@ -80,6 +80,7 @@ public class OfflineTeleportCommand {
                     if (location != null) return sender.teleportAsync(location, COMMAND);
                     return CompletableFuture.completedFuture(false);
                 }).thenAccept(success -> {
+                    if (Boolean.FALSE.equals(sender.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
                     var message = success ? "command.offline.teleport.success.to" : "command.offline.teleport.fail.to";
                     plugin.bundle().sendMessage(sender, message, placeholder);
                 }).exceptionally(throwable -> {

--- a/src/main/java/net/thenextlvl/tweaks/command/player/SpeedCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/SpeedCommand.java
@@ -11,6 +11,7 @@ import io.papermc.paper.command.brigadier.argument.resolvers.selector.EntitySele
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
@@ -115,6 +116,8 @@ public class SpeedCommand {
                 if (type.equals(SpeedType.WALK)) player.setWalkSpeed(0.2f);
             }
 
+            if (Boolean.FALSE.equals(entity.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
+            
             plugin.bundle().sendMessage(entity, "command.speed.reset.self");
             if (!entity.equals(sender)) plugin.bundle().sendMessage(sender, "command.speed.reset.others",
                     Placeholder.component("entity", entity.name().hoverEvent(entity.asHoverEvent())));
@@ -140,6 +143,9 @@ public class SpeedCommand {
                     instance.addTransientModifier(modifier);
                 }
             }
+
+
+            if (Boolean.FALSE.equals(entity.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
 
             plugin.bundle().sendMessage(entity, type.getMessageSelf(),
                     Formatter.number("speed", speed));

--- a/src/main/java/net/thenextlvl/tweaks/command/player/SuicideCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/player/SuicideCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.damage.DamageType;
 import org.bukkit.entity.Player;
@@ -30,7 +31,8 @@ public class SuicideCommand {
     private int suicide(CommandContext<CommandSourceStack> context) {
         var player = (Player) context.getSource().getSender();
         player.damage(player.getHealth(), DamageSource.builder(DamageType.GENERIC_KILL).build());
-        plugin.bundle().sendMessage(player, "command.suicide");
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(player, "command.suicide");
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/spawn/SetSpawnCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/spawn/SetSpawnCommand.java
@@ -12,6 +12,7 @@ import io.papermc.paper.math.FinePosition;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
@@ -76,13 +77,14 @@ public class SetSpawnCommand {
         plugin.config().spawn.location = position.toLocation(world);
         plugin.saveConfig();
 
-        plugin.bundle().sendMessage(context.getSource().getSender(), "command.spawn.set",
-                Placeholder.parsed("world", world.getName()),
-                Formatter.number("x", position.x()),
-                Formatter.number("y", position.y()),
-                Formatter.number("z", position.z()),
-                Formatter.number("yaw", yaw),
-                Formatter.number("pitch", pitch));
+        if (Boolean.TRUE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)))
+            plugin.bundle().sendMessage(context.getSource().getSender(), "command.spawn.set",
+                    Placeholder.parsed("world", world.getName()),
+                    Formatter.number("x", position.x()),
+                    Formatter.number("y", position.y()),
+                    Formatter.number("z", position.z()),
+                    Formatter.number("yaw", yaw),
+                    Formatter.number("pitch", pitch));
 
         if (context.getSource().getSender() instanceof Player player)
             player.teleportAsync(position.toLocation(world), PlayerTeleportEvent.TeleportCause.COMMAND);

--- a/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
@@ -1,8 +1,11 @@
 package net.thenextlvl.tweaks.command.spawn;
 
 import com.mojang.brigadier.Command;
+import com.mojang.brigadier.context.CommandContext;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import net.thenextlvl.tweaks.TweaksPlugin;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -20,20 +23,23 @@ public class SpawnCommand {
         var command = Commands.literal(plugin.commands().spawn.command)
                 .requires(stack -> stack.getSender() instanceof Player player
                                    && player.hasPermission("tweaks.command.spawn"))
-                .executes(context -> {
-                    var player = (Player) context.getSource().getSender();
-                    var location = plugin.config().spawn.location;
-                    if (location == null || location.getWorld() == null) {
-                        plugin.bundle().sendMessage(player, "command.spawn.undefined");
-                        if (player.hasPermission("tweaks.command.setspawn"))
-                            plugin.bundle().sendMessage(player, "command.spawn.define");
-                        return 0;
-                    } else plugin.teleportController().teleport(player, location, COMMAND).thenAccept(success -> {
-                        var message = success ? "command.spawn" : "command.teleport.cancelled";
-                        plugin.bundle().sendMessage(player, message);
-                    });
-                    return Command.SINGLE_SUCCESS;
-                }).build();
+                .executes(this::spawn).build();
         registrar.register(command, "Teleport you to spawn", plugin.commands().spawn.aliases);
+    }
+
+    private int spawn(CommandContext<CommandSourceStack> context) {
+        var player = (Player) context.getSource().getSender();
+        var location = plugin.config().spawn.location;
+        if (location == null || location.getWorld() == null) {
+            plugin.bundle().sendMessage(player, "command.spawn.undefined");
+            if (player.hasPermission("tweaks.command.setspawn"))
+                plugin.bundle().sendMessage(player, "command.spawn.define");
+            return 0;
+        } else plugin.teleportController().teleport(player, location, COMMAND).thenAccept(success -> {
+            var message = success ? "command.spawn" : "command.teleport.cancelled";
+            if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+                plugin.bundle().sendMessage(player, message);
+        });
+        return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/tpa/TPADenyCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/tpa/TPADenyCommand.java
@@ -8,6 +8,7 @@ import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.RequestSuggestionProvider;
 import net.thenextlvl.tweaks.controller.TPAController;
 import net.thenextlvl.tweaks.controller.TPAController.RequestType;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -47,11 +48,12 @@ public class TPADenyCommand {
 
     static int deny(TweaksPlugin plugin, Player sender, @Nullable Player player, RequestType type) {
         var success = player != null && plugin.tpaController().removeRequest(sender, player, type);
-        var message = player != null && success ? "command.tpa.denied.self"
+        var message = success ? "command.tpa.denied.self"
                 : player != null ? "command.tpa.no-request"
                 : "command.tpa.no-requests";
-        plugin.bundle().sendMessage(sender, message,
-                Placeholder.parsed("player", player != null ? player.getName() : "null"));
+        if (Boolean.TRUE.equals(sender.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(sender, message,
+                    Placeholder.parsed("player", player != null ? player.getName() : "null"));
         if (player != null && success) plugin.bundle().sendMessage(player, "command.tpa.denied",
                 Placeholder.parsed("player", sender.getName()));
         return player != null ? Command.SINGLE_SUCCESS : 0;

--- a/src/main/java/net/thenextlvl/tweaks/command/tpa/TPAcceptCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/tpa/TPAcceptCommand.java
@@ -8,6 +8,7 @@ import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.RequestSuggestionProvider;
 import net.thenextlvl.tweaks.controller.TPAController.Request;
 import net.thenextlvl.tweaks.controller.TPAController.RequestType;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -54,10 +55,12 @@ public class TPAcceptCommand {
             return 0;
         }
 
-        plugin.bundle().sendMessage(sender, "command.tpa.accepted.self",
-                Placeholder.parsed("player", player.getName()));
-        plugin.bundle().sendMessage(player, "command.tpa.accepted",
-                Placeholder.parsed("player", sender.getName()));
+        if (Boolean.TRUE.equals(sender.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) {
+            plugin.bundle().sendMessage(sender, "command.tpa.accepted.self",
+                    Placeholder.parsed("player", player.getName()));
+            plugin.bundle().sendMessage(player, "command.tpa.accepted",
+                    Placeholder.parsed("player", sender.getName()));
+        }
 
         if (type.equals(TPA)) teleport(plugin, player, sender); // sender accepts the tpa - teleport player to sender
         else teleport(plugin, sender, player); // sender accepts the tpahere - teleport sender to player
@@ -68,7 +71,8 @@ public class TPAcceptCommand {
     private static void teleport(TweaksPlugin plugin, Player player, Player target) {
         plugin.teleportController().teleport(player, target.getLocation(), COMMAND).thenAccept(success -> {
             var message = success ? "command.tpa.teleported" : "command.teleport.cancelled";
-            plugin.bundle().sendMessage(player, message, Placeholder.parsed("player", target.getName()));
+            if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+                plugin.bundle().sendMessage(player, message, Placeholder.parsed("player", target.getName()));
         });
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/tpa/TPAskCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/tpa/TPAskCommand.java
@@ -12,6 +12,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.TPASuggestionProvider;
 import net.thenextlvl.tweaks.controller.TPAController.RequestType;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -61,8 +62,9 @@ public class TPAskCommand {
         }
 
         var success = plugin.tpaController().addRequest(player, sender, type);
-        plugin.bundle().sendMessage(sender, success ? type.outgoingMessage() : "command.tpa.sent",
-                Placeholder.parsed("player", player.getName()));
+        if (Boolean.TRUE.equals(player.getWorld().getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) || !success)
+            plugin.bundle().sendMessage(sender, success ? type.outgoingMessage() : "command.tpa.sent",
+                    Placeholder.parsed("player", player.getName()));
 
         if (!success) return false;
 

--- a/src/main/java/net/thenextlvl/tweaks/command/warp/DeleteWarpCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/warp/DeleteWarpCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.WarpSuggestionProvider;
+import org.bukkit.GameRule;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -31,6 +32,8 @@ public class DeleteWarpCommand {
     private int deleteWarp(CommandContext<CommandSourceStack> context) {
         var name = context.getArgument("name", String.class);
         plugin.warpController().deleteWarp(name).thenAccept(success -> {
+            var world = context.getSource().getLocation().getWorld();
+            if (Boolean.FALSE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) && success) return;
             var message = success ? "command.warp.delete" : "command.warp.unknown";
             plugin.bundle().sendMessage(context.getSource().getSender(), message,
                     Placeholder.parsed("name", name));

--- a/src/main/java/net/thenextlvl/tweaks/command/warp/SetWarpCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/warp/SetWarpCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.WarpSuggestionProvider;
+import org.bukkit.GameRule;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -30,9 +31,12 @@ public class SetWarpCommand {
 
     private int setWarp(CommandContext<CommandSourceStack> context) {
         var name = context.getArgument("name", String.class);
-        plugin.warpController().setWarp(name, context.getSource().getLocation())
-                .thenAccept(unused -> plugin.bundle().sendMessage(context.getSource().getSender(),
-                        "command.warp.set", Placeholder.parsed("name", name)));
+        plugin.warpController().setWarp(name, context.getSource().getLocation()).thenAccept(unused -> {
+            var world = context.getSource().getLocation().getWorld();
+            if (Boolean.FALSE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK))) return;
+            plugin.bundle().sendMessage(context.getSource().getSender(),
+                    "command.warp.set", Placeholder.parsed("name", name));
+        });
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/net/thenextlvl/tweaks/command/warp/WarpCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/warp/WarpCommand.java
@@ -8,6 +8,7 @@ import io.papermc.paper.command.brigadier.Commands;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.tweaks.TweaksPlugin;
 import net.thenextlvl.tweaks.command.suggestion.WarpSuggestionProvider;
+import org.bukkit.GameRule;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -38,6 +39,8 @@ public class WarpCommand {
         plugin.warpController().getWarp(name).thenAccept(warp -> warp.ifPresentOrElse(location ->
                 plugin.teleportController().teleport(player, location, COMMAND).thenAccept(success -> {
                     var message = success ? "command.warp" : "command.teleport.cancelled";
+                    var world = context.getSource().getLocation().getWorld();
+                    if (Boolean.FALSE.equals(world.getGameRuleValue(GameRule.SEND_COMMAND_FEEDBACK)) && success) return;
                     plugin.bundle().sendMessage(player, message, Placeholder.parsed("name", name));
                 }), () -> plugin.bundle().sendMessage(player, "command.warp.unknown", Placeholder.parsed("name", name))));
         return Command.SINGLE_SUCCESS;


### PR DESCRIPTION
Add support for the `sendCommandFeedback` game rule across commands to control feedback messages dynamically. Error messages are still printed.
Commands that have no other way of feedback like visual changes still send feedback even when the gamerule is disabled.