### PR TITLE
Added option to allow unsafe enchantments

### DIFF
--- a/src/main/java/net/thenextlvl/tweaks/command/item/EnchantCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/item/EnchantCommand.java
@@ -42,7 +42,7 @@ public class EnchantCommand {
                 .requires(stack -> stack.getSender() instanceof Player player
                                    && player.hasPermission("tweaks.command.enchant"))
                 .then(Commands.argument("enchantment", ArgumentTypes.resourceKey(RegistryKey.ENCHANTMENT))
-                        .suggests(new EnchantSuggestionProvider())
+                        .suggests(new EnchantSuggestionProvider(plugin))
                         .then(Commands.argument("level", IntegerArgumentType.integer(1, max))
                                 .suggests(this::suggestLevels)
                                 .executes(context -> enchant(context, context.getArgument("level", int.class))))
@@ -79,7 +79,7 @@ public class EnchantCommand {
             plugin.bundle().sendMessage(player, "command.hold.item");
             return 0;
         }
-        if (!enchantment.canEnchantItem(item)) {
+        if (!plugin.config().general.unsafeEnchantments && !enchantment.canEnchantItem(item)) {
             plugin.bundle().sendMessage(player, "command.enchantment.applicable",
                     Placeholder.component("item", Component.translatable(item)));
             return 0;

--- a/src/main/java/net/thenextlvl/tweaks/command/suggestion/EnchantSuggestionProvider.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/suggestion/EnchantSuggestionProvider.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.registry.RegistryAccess;
 import io.papermc.paper.registry.RegistryKey;
+import net.thenextlvl.tweaks.TweaksPlugin;
 import org.bukkit.entity.Player;
 import org.jspecify.annotations.NullMarked;
 
@@ -14,13 +15,20 @@ import java.util.concurrent.CompletableFuture;
 
 @NullMarked
 public class EnchantSuggestionProvider implements SuggestionProvider<CommandSourceStack> {
+    private final TweaksPlugin plugin;
+
+    public EnchantSuggestionProvider(TweaksPlugin plugin) {
+        this.plugin = plugin;
+    }
+
     @Override
     public CompletableFuture<Suggestions> getSuggestions(CommandContext<CommandSourceStack> context, SuggestionsBuilder builder) {
         if (!(context.getSource().getSender() instanceof Player player)) return builder.buildFuture();
         var item = player.getInventory().getItemInMainHand();
         RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).stream()
-                .filter(enchantment -> enchantment.canEnchantItem(item))
-                .filter(enchantment -> item.getEnchantments().containsKey(enchantment)
+                .filter(enchantment -> plugin.config().general.unsafeEnchantments || enchantment.canEnchantItem(item))
+                .filter(enchantment -> plugin.config().general.unsafeEnchantments
+                                       || item.getEnchantments().containsKey(enchantment)
                                        || item.getEnchantments().keySet().stream().noneMatch(enchantment::conflictsWith))
                 .map(enchantment -> enchantment.key().asString())
                 .filter(s -> s.contains(builder.getRemaining()))

--- a/src/main/java/net/thenextlvl/tweaks/model/PluginConfig.java
+++ b/src/main/java/net/thenextlvl/tweaks/model/PluginConfig.java
@@ -26,6 +26,7 @@ public class PluginConfig {
         public @SerializedName("message-deletion-timeout") long messageDeletionTimeout = TimeUnit.MINUTES.toMillis(10);
         public @SerializedName("back-buffer-stack-size") int backBufferStackSize = 5;
         public @SerializedName("default-permission-level") byte defaultPermissionLevel = -1;
+        public @SerializedName("allow-unsafe-enchantments") boolean unsafeEnchantments = false;
         public @SerializedName("enchantment-overflow") boolean enchantmentOverflow = false;
         public @SerializedName("override-join-message") boolean overrideJoinMessage = true;
         public @SerializedName("override-quit-message") boolean overrideQuitMessage = true;


### PR DESCRIPTION
Closes #77 

Added new config option `allow-unsafe-enchantments` to enable bypassing standard enchantment restrictions. Updated related command logic to respect this configuration.