### PR TITLE
Fix spawn being deleted after restart

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ paper {
     apiVersion = "1.21.5"
     website = "https://thenextlvl.net"
     authors = listOf("CyntrixAlgorithm", "NonSwag")
-    load = BukkitPluginDescription.PluginLoadOrder.STARTUP
+    load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
 
     foliaSupported = true
 

--- a/src/main/java/net/thenextlvl/tweaks/TweaksPlugin.java
+++ b/src/main/java/net/thenextlvl/tweaks/TweaksPlugin.java
@@ -95,7 +95,7 @@ public class TweaksPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        initConfigs();
+        initConfig();
         initTranslations();
         initControllers();
         initMotd();
@@ -295,7 +295,7 @@ public class TweaksPlugin extends JavaPlugin {
         if (config != null) config.save();
     }
 
-    private void initConfigs() {
+    private void initConfig() {
         this.config = new GsonFile<>(
                 IO.of(getDataFolder(), "config.json"),
                 new PluginConfig(), new GsonBuilder()

--- a/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
+++ b/src/main/java/net/thenextlvl/tweaks/command/spawn/SpawnCommand.java
@@ -30,7 +30,7 @@ public class SpawnCommand {
     private int spawn(CommandContext<CommandSourceStack> context) {
         var player = (Player) context.getSource().getSender();
         var location = plugin.config().spawn.location;
-        if (location == null || location.getWorld() == null) {
+        if (location == null || !location.isWorldLoaded()) {
             plugin.bundle().sendMessage(player, "command.spawn.undefined");
             if (player.hasPermission("tweaks.command.setspawn"))
                 plugin.bundle().sendMessage(player, "command.spawn.define");

--- a/src/main/java/net/thenextlvl/tweaks/listener/SpawnListener.java
+++ b/src/main/java/net/thenextlvl/tweaks/listener/SpawnListener.java
@@ -20,7 +20,7 @@ public class SpawnListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerSpawnLocation(PlayerSpawnLocationEvent event) {
         var config = plugin.config().spawn;
-        if (config.location == null || config.location.getWorld() == null) return;
+        if (config.location == null || !config.location.isWorldLoaded()) return;
         if ((!config.teleportOnFirstJoin || event.getPlayer().hasPlayedBefore())
             && (!config.teleportOnJoin || !event.getPlayer().hasPlayedBefore())) return;
         event.setSpawnLocation(config.location);
@@ -30,7 +30,7 @@ public class SpawnListener implements Listener {
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         if (!event.getRespawnReason().equals(PlayerRespawnEvent.RespawnReason.DEATH)) return;
         var config = plugin.config().spawn;
-        if (config.location == null || config.location.getWorld() == null || !config.teleportOnRespawn) return;
+        if (config.location == null || !config.location.isWorldLoaded() || !config.teleportOnRespawn) return;
         if (!config.ignoreRespawnPosition && (event.isAnchorSpawn() || event.isBedSpawn())) return;
         event.setRespawnLocation(config.location);
     }
@@ -38,7 +38,7 @@ public class SpawnListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerDeath(PlayerDeathEvent event) {
         var config = plugin.config().spawn;
-        if (config.location == null || config.location.getWorld() == null || !config.teleportOnRespawn) return;
+        if (config.location == null || !config.location.isWorldLoaded() || !config.teleportOnRespawn) return;
         if (config.ignoreRespawnPosition) event.getPlayer().setRespawnLocation(null);
     }
 }


### PR DESCRIPTION
- Reverted the plugin load order change to resolve an issue where the spawn world was null during startup, which caused the spawn location to be deleted.
- Replaced the world null check for teleport locations with a call to `isWorldLoaded()` to prevent teleportation to unloaded worlds.