### PR TITLE
Revised plugin load order for `ServiceIO`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,7 @@ paper {
 
     serverDependencies {
         register("ServiceIO") {
-            load = PaperPluginDescription.RelativeLoadOrder.BEFORE
+            load = PaperPluginDescription.RelativeLoadOrder.AFTER
             required = false
         }
     }


### PR DESCRIPTION
Fixes #127 

Changed load order from `BEFORE` to `AFTER` to ensure proper dependency sequencing.